### PR TITLE
[Bug fix] SMF only relies on 1 database "sdcore_smf"

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -29,9 +29,7 @@ provides:
     interface: prometheus_scrape
 
 requires:
-  default-database:
-    interface: mongodb_client
-  smf-database:
+  database:
     interface: mongodb_client
   fiveg_nrf:
     interface: fiveg_nrf

--- a/src/templates/smfcfg.yaml.j2
+++ b/src/templates/smfcfg.yaml.j2
@@ -20,7 +20,7 @@ configuration:
   sbi: # Service-based interface information
     scheme: http # the protocol for sbi (http or https)
     registerIPv4: {{ smf_url }} # IP used to register to NRF
-    bindingIPv4: smf # IP used to bind the service
+    bindingIPv4: 0.0.0.0 # IP used to bind the service
     port: {{ smf_sbi_port }} # Port used to bind the service
     tls: # the local path of TLS key
       key: free5gc/support/TLS/smf.key # SMF TLS Certificate

--- a/src/templates/smfcfg.yaml.j2
+++ b/src/templates/smfcfg.yaml.j2
@@ -14,7 +14,6 @@ configuration:
   enableUPFAdapter: false
   debugProfilePort: 5001
   mongodb:
-    name: free5gc
     url: {{ database_url }}
   smfName: SMF # the name of this SMF
   sbi: # Service-based interface information

--- a/src/templates/smfcfg.yaml.j2
+++ b/src/templates/smfcfg.yaml.j2
@@ -9,13 +9,13 @@ info:
   description: SMF initial local configuration
 
 configuration:
-  smfDBName: {{ smf_database_name }}
+  smfDBName: {{ database_name }}
   enableDBStore: false
-  enableUPFAdapter: true
+  enableUPFAdapter: false
   debugProfilePort: 5001
   mongodb:
-    name: {{ default_database_name }}
-    url: {{ default_database_url }}
+    name: free5gc
+    url: {{ database_url }}
   smfName: SMF # the name of this SMF
   sbi: # Service-based interface information
     scheme: http # the protocol for sbi (http or https)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -76,10 +76,7 @@ async def test_relate_and_wait_for_active_status(
         relation1=f"{NRF_APP_NAME}:database", relation2=f"{DATABASE_APP_NAME}"
     )
     await ops_test.model.add_relation(
-        relation1=f"{APP_NAME}:default-database", relation2=f"{DATABASE_APP_NAME}"
-    )
-    await ops_test.model.add_relation(
-        relation1=f"{APP_NAME}:smf-database", relation2=f"{DATABASE_APP_NAME}"
+        relation1=f"{APP_NAME}:database", relation2=f"{DATABASE_APP_NAME}"
     )
     await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_APP_NAME)
     await ops_test.model.wait_for_idle(

--- a/tests/unit/expected_smfcfg.yaml
+++ b/tests/unit/expected_smfcfg.yaml
@@ -14,7 +14,6 @@ configuration:
   enableUPFAdapter: false
   debugProfilePort: 5001
   mongodb:
-    name: free5gc
     url: http://6.5.6.5
   smfName: SMF # the name of this SMF
   sbi: # Service-based interface information

--- a/tests/unit/expected_smfcfg.yaml
+++ b/tests/unit/expected_smfcfg.yaml
@@ -11,11 +11,11 @@ info:
 configuration:
   smfDBName: sdcore_smf
   enableDBStore: false
-  enableUPFAdapter: true
+  enableUPFAdapter: false
   debugProfilePort: 5001
   mongodb:
     name: free5gc
-    url: http://1.1.1.1
+    url: http://6.5.6.5
   smfName: SMF # the name of this SMF
   sbi: # Service-based interface information
     scheme: http # the protocol for sbi (http or https)

--- a/tests/unit/expected_smfcfg.yaml
+++ b/tests/unit/expected_smfcfg.yaml
@@ -20,7 +20,7 @@ configuration:
   sbi: # Service-based interface information
     scheme: http # the protocol for sbi (http or https)
     registerIPv4: sdcore-smf.whatever.svc.cluster.local # IP used to register to NRF
-    bindingIPv4: smf # IP used to bind the service
+    bindingIPv4: 0.0.0.0 # IP used to bind the service
     port: 29502 # Port used to bind the service
     tls: # the local path of TLS key
       key: free5gc/support/TLS/smf.key # SMF TLS Certificate


### PR DESCRIPTION
# Description

- Removes the default database that was never used in the charm
- Uses the URL from the "sdcore_smf" database to enter into the smf configuration file
- Sets `enableUPFAdapter` to false
- Sets `bindingIPv4` to `0.0.0.0`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
