### PR TITLE
Change default log level to info

### DIFF
--- a/src/templates/smfcfg.yaml.j2
+++ b/src/templates/smfcfg.yaml.j2
@@ -37,24 +37,24 @@ configuration:
 # ReportCaller: enable the caller report or not, value: true or false
 logger:
   SMF:
-    debugLevel: debug
+    debugLevel: info
     ReportCaller: false
   NAS:
-    debugLevel: debug
+    debugLevel: info
     ReportCaller: false
   NGAP:
-    debugLevel: debug
+    debugLevel: info
     ReportCaller: false
   Aper:
     debugLevel: info
     ReportCaller: false
   PathUtil:
-    debugLevel: debug
+    debugLevel: info
     ReportCaller: false
   OpenApi:
-    debugLevel: debug
+    debugLevel: info
     ReportCaller: false
   PFCP:
-    debugLevel: debug
+    debugLevel: info
     ReportCaller: false
 

--- a/tests/unit/expected_smfcfg.yaml
+++ b/tests/unit/expected_smfcfg.yaml
@@ -37,23 +37,23 @@ configuration:
 # ReportCaller: enable the caller report or not, value: true or false
 logger:
   SMF:
-    debugLevel: debug
+    debugLevel: info
     ReportCaller: false
   NAS:
-    debugLevel: debug
+    debugLevel: info
     ReportCaller: false
   NGAP:
-    debugLevel: debug
+    debugLevel: info
     ReportCaller: false
   Aper:
     debugLevel: info
     ReportCaller: false
   PathUtil:
-    debugLevel: debug
+    debugLevel: info
     ReportCaller: false
   OpenApi:
-    debugLevel: debug
+    debugLevel: info
     ReportCaller: false
   PFCP:
-    debugLevel: debug
+    debugLevel: info
     ReportCaller: false


### PR DESCRIPTION
# Description

This change should prevent the Kafka error logs from coming out, following upstream deployments' configuration.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
