### PR TITLE
Uses ROCK for smf instead of upstream image

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ juju integrate sdcore-smf:fiveg_nrf sdcore-nrf
 
 # Image
 
-**smf**: `omecproject/5gc-smf:master-3fa04ea`
+**smf**: `ghcr.io/canonical/sdcore-smf:1.3`

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,7 +17,7 @@ resources:
   smf-image:
     type: oci-image
     description: OCI image for 5G SMF
-    upstream-source: omecproject/5gc-smf:master-3fa04ea
+    upstream-source: ghcr.io/canonical/sdcore-smf:1.3
 
 storage:
   config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -310,7 +310,7 @@ class SMFOperatorCharm(CharmBase):
                 self._service_name: {
                     "override": "replace",
                     "startup": "enabled",
-                    "command": f"/free5gc/smf/smf -smfcfg {BASE_CONFIG_PATH}/{CONFIG_FILE} "
+                    "command": f"/bin/smf -smfcfg {BASE_CONFIG_PATH}/{CONFIG_FILE} "
                     f"-uerouting {BASE_CONFIG_PATH}/{UEROUTING_CONFIG_FILE}",
                     "environment": self._environment_variables,
                 }

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -395,7 +395,7 @@ class TestCharm(unittest.TestCase):
                 "smf": {
                     "override": "replace",
                     "startup": "enabled",
-                    "command": "/free5gc/smf/smf -smfcfg /etc/smf/smfcfg.yaml "
+                    "command": "/bin/smf -smfcfg /etc/smf/smfcfg.yaml "
                     "-uerouting /etc/smf/uerouting.yaml",
                     "environment": {
                         "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",


### PR DESCRIPTION
# Description

Uses ROCK for smf instead of upstream image

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
