### PR TITLE
Enforce TLS Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,11 @@ Charmed Operator for the SD-Core Session Management Function (SMF).
 juju deploy mongodb-k8s --channel 5/edge --trust
 juju deploy sdcore-smf --channel edge --trust
 juju deploy sdcore-nrf --channel edge --trust
+juju deploy self-signed-certificates --channel=beta
 juju integrate sdcore-smf:default-database mongodb-k8s
 juju integrate sdcore-smf:smf-database mongodb-k8s
+juju integrate sdcore-nrf:certificates self-signed-certificates:certificates
 juju integrate sdcore-smf:fiveg_nrf sdcore-nrf
-```
-
-### Optional
-
-```bash
-juju deploy self-signed-certificates --channel=edge
 juju integrate sdcore-smf:certificates self-signed-certificates:certificates
 ```
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -118,13 +118,13 @@ class SMFOperatorCharm(CharmBase):
             return
         self._write_ue_config_file()
 
-    def _configure_sdcore_smf(self, event: EventBase) -> None:
+    def _configure_sdcore_smf(self, event: EventBase) -> None:  # noqa C901
         """Adds pebble layer and manages Juju unit status.
 
         Args:
             event: Juju event
         """
-        for relation in ["database", "fiveg_nrf"]:
+        for relation in ["database", "fiveg_nrf", "certificates"]:
             if not self._relation_created(relation):
                 self.unit.status = BlockedStatus(
                     f"Waiting for `{relation}` relation to be created"
@@ -152,6 +152,10 @@ class SMFOperatorCharm(CharmBase):
             self.unit.status = WaitingStatus(
                 f"Waiting for `{UEROUTING_CONFIG_FILE}` config file to be pushed to workload container"  # noqa: W505, E501
             )
+            return
+        if not self._certificate_is_stored():
+            self.unit.status = WaitingStatus("Waiting for certificates to be stored")
+            event.defer()
             return
         if self._update_config_file():
             self._configure_pebble(restart=True)
@@ -182,7 +186,7 @@ class SMFOperatorCharm(CharmBase):
         self._delete_private_key()
         self._delete_csr()
         self._delete_certificate()
-        self._configure_sdcore_smf(event)
+        self.unit.status = BlockedStatus("Waiting for certificate relation")
 
     def _on_certificates_relation_joined(self, event: EventBase) -> None:
         """Generates CSR and requests new certificate."""
@@ -326,7 +330,7 @@ class SMFOperatorCharm(CharmBase):
             smf_sbi_port=SMF_SBI_PORT,
             nrf_url=self._nrf_requires.nrf_url,
             pod_ip=_get_pod_ip(),  # type: ignore[arg-type]
-            scheme="https" if self._certificate_is_stored() else "http",
+            scheme="https",
             tls_key_path=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}",
             tls_certificate_path=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}",
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -118,7 +118,7 @@ class SMFOperatorCharm(CharmBase):
             return
         self._write_ue_config_file()
 
-    def _missing_mandatory_relations(self) -> str:
+    def _missing_mandatory_relations(self) -> Optional[str]:
         """Returns whether a mandatory Juju relation is missing.
 
         Returns:
@@ -127,6 +127,7 @@ class SMFOperatorCharm(CharmBase):
         for relation in ["database", "fiveg_nrf", "certificates"]:
             if not self._relation_created(relation):
                 return relation
+        return None
 
     def _configure_sdcore_smf(self, event: EventBase) -> None:
         """Adds pebble layer and manages Juju unit status.

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -44,7 +44,7 @@ async def _deploy_tls_provider(ops_test: OpsTest):
     await ops_test.model.deploy(  # type: ignore[union-attr]
         TLS_PROVIDER_APP_NAME,
         application_name=TLS_PROVIDER_APP_NAME,
-        channel="edge",
+        channel="beta",
     )
 
 
@@ -86,6 +86,7 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, build_and_de
     await ops_test.model.add_relation(  # type: ignore[union-attr]
         relation1=f"{APP_NAME}:database", relation2=f"{DATABASE_APP_NAME}"
     )
+    await ops_test.model.add_relation(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
     await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
     await ops_test.model.add_relation(relation1=APP_NAME, relation2=TLS_PROVIDER_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
     await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
@@ -112,5 +113,26 @@ async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, build_a
     await ops_test.model.add_relation(  # type: ignore[union-attr]
         relation1=f"{NRF_APP_NAME}:database", relation2=DATABASE_APP_NAME
     )
+    await ops_test.model.add_relation(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
     await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501
+
+
+@pytest.mark.abort_on_fail
+async def test_remove_tls_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
+    await ops_test.model.remove_application(TLS_PROVIDER_APP_NAME, block_until_done=True)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)  # type: ignore[union-attr]  # noqa: E501
+
+
+@pytest.mark.abort_on_fail
+async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
+    await ops_test.model.deploy(  # type: ignore[union-attr]
+        TLS_PROVIDER_APP_NAME,
+        application_name=TLS_PROVIDER_APP_NAME,
+        channel="beta",
+        trust=True,
+    )
+    await ops_test.model.add_relation(  # type: ignore[union-attr]
+        relation1=APP_NAME, relation2=TLS_PROVIDER_APP_NAME
+    )
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -40,7 +40,7 @@ async def _deploy_nrf(ops_test: OpsTest):
 
 
 async def _deploy_tls_provider(ops_test: OpsTest):
-    """Deploy a NRF."""
+    """Deploy a TLS provider."""
     await ops_test.model.deploy(  # type: ignore[union-attr]
         TLS_PROVIDER_APP_NAME,
         application_name=TLS_PROVIDER_APP_NAME,

--- a/tests/unit/expected_smfcfg.yaml
+++ b/tests/unit/expected_smfcfg.yaml
@@ -17,7 +17,7 @@ configuration:
     url: http://6.5.6.5
   smfName: SMF
   sbi:
-    scheme: http
+    scheme: https
     registerIPv4: sdcore-smf.whatever.svc.cluster.local
     bindingIPv4: 0.0.0.0
     port: 29502

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -163,6 +163,19 @@ class TestCharm(unittest.TestCase):
             BlockedStatus("Waiting for `fiveg_nrf` relation to be created"),
         )
 
+    def test_given_certificates_relation_not_created_when_configure_sdcore_smf_is_called_then_status_is_blocked(  # noqa: E501
+        self,
+    ):
+        self._create_database_relation()
+        self._create_nrf_relation()
+
+        self.harness.charm._configure_sdcore_smf(event=Mock())
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("Waiting for `certificates` relation to be created"),
+        )
+
     @patch("ops.model.Container.pull", new=Mock)
     @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url")
     @patch("ops.model.Container.push", new=Mock)
@@ -191,6 +204,9 @@ class TestCharm(unittest.TestCase):
     ):
         self._create_database_relation()
         self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
         self.harness.set_can_connect(container=self.container_name, val=False)
 
         self.harness.charm._configure_sdcore_smf(event=Mock())
@@ -204,6 +220,9 @@ class TestCharm(unittest.TestCase):
     ):
         self._create_database_relation()
         self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
         self.harness.set_can_connect(container=self.container_name, val=True)
 
         self.harness.charm._configure_sdcore_smf(event=Mock())
@@ -218,6 +237,9 @@ class TestCharm(unittest.TestCase):
     ):
         self._database_is_available()
         self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
         self.harness.set_can_connect(container=self.container_name, val=True)
 
         self.harness.charm._configure_sdcore_smf(event=Mock())
@@ -238,6 +260,9 @@ class TestCharm(unittest.TestCase):
     ):
         self._database_is_available()
         self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
         patch_check_output.return_value = b"1.1.1.1"
         self.harness.set_can_connect(container=self.container_name, val=True)
         patch_exists.side_effect = [True, False]
@@ -254,38 +279,22 @@ class TestCharm(unittest.TestCase):
 
     @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url")
     @patch("ops.model.Container.exists")
+    @patch("ops.model.Container.push")
     def test_given_storage_is_not_attached_when_configure_sdcore_smf_is_called_then_status_is_waiting(  # noqa: E501
-        self, patch_exists, patch_nrf_url
+        self, patch_push, patch_exists, patch_nrf_url
     ):
         self._database_is_available()
         self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
         self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_exists.return_value = [False]
+        patch_exists.side_effect = [False, False]
         patch_nrf_url.return_value = "http://nrf.com:8080"
-
-    @patch("ops.model.Container.pull", new=Mock)
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url")
-    @patch("ops.model.Container.push", new=Mock)
-    @patch("charm.check_output")
-    @patch("ops.model.Container.exists")
-    def test_given_config_files_and_relations_are_created_when_configure_sdcore_smf_is_called_then_status_is_active(  # noqa: E501
-        self,
-        patch_exists,
-        patch_check_output,
-        patch_nrf_url,
-    ):
-        self._database_is_available()
-        self._create_nrf_relation()
-        self.harness.set_can_connect(container=self.container_name, val=True)
-        patch_exists.return_value = True
-        patch_check_output.return_value = b"1.1.1.1"
-        patch_nrf_url.return_value = "http://nrf.com:8080"
-
         self.harness.charm._configure_sdcore_smf(event=Mock())
-
         self.assertEqual(
             self.harness.model.unit.status,
-            ActiveStatus(),
+            WaitingStatus("Waiting for storage to be attached"),
         )
 
     @patch("ops.model.Container.pull", new=Mock)
@@ -301,7 +310,11 @@ class TestCharm(unittest.TestCase):
     ):
         self._database_is_available()
         self._create_nrf_relation()
-        patch_exists.side_effect = [True, True, True]
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
+        self.harness.charm._certificate_is_stored = Mock(return_value=True)
+        patch_exists.return_value = True
         patch_check_output.return_value = b""
         patch_nrf_url.return_value = "http://nrf.com:8080"
 
@@ -310,6 +323,62 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for pod IP address to be available"),
+        )
+
+    @patch("charm.check_output")
+    @patch("ops.model.Container.push")
+    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    def test_given_certificate_is_not_stored_when_configure_sdcore_smff_then_status_is_waiting(  # noqa: E501
+        self,
+        patch_nrf_url,
+        patch_push,
+        patch_check_output,
+    ):
+        self.harness.set_can_connect(container=self.container_name, val=True)
+        patch_nrf_url.return_value = "http://nrf.com:8080"
+        self._database_is_available()
+        self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
+        self.harness.charm._storage_is_attached = Mock(return_value=True)
+        self.harness.charm._ue_config_file_is_written = Mock(return_value=True)
+        self.harness.charm._certificate_is_stored = Mock(return_value=False)
+        patch_check_output.return_value = b"1.1.1.1"
+
+        self.harness.charm._configure_sdcore_smf(event=Mock())
+
+        self.assertEqual(
+            self.harness.model.unit.status, WaitingStatus("Waiting for certificates to be stored")
+        )
+
+    @patch("ops.model.Container.pull", new=Mock)
+    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url")
+    @patch("ops.model.Container.push", new=Mock)
+    @patch("charm.check_output")
+    @patch("ops.model.Container.exists")
+    def test_given_config_files_and_relations_are_created_when_configure_sdcore_smf_is_called_then_status_is_active(  # noqa: E501
+        self,
+        patch_exists,
+        patch_check_output,
+        patch_nrf_url,
+    ):
+        self._database_is_available()
+        self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
+        self.harness.charm._certificate_is_stored = Mock(return_value=True)
+        self.harness.set_can_connect(container=self.container_name, val=True)
+        patch_exists.return_value = True
+        patch_check_output.return_value = b"1.1.1.1"
+        patch_nrf_url.return_value = "http://nrf.com:8080"
+
+        self.harness.charm._configure_sdcore_smf(event=Mock())
+
+        self.assertEqual(
+            self.harness.model.unit.status,
+            ActiveStatus(),
         )
 
     @patch("ops.model.Container.pull", new=Mock)
@@ -328,8 +397,12 @@ class TestCharm(unittest.TestCase):
         patch_check_output.return_value = pod_ip.encode()
         self._database_is_available()
         self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
+        self.harness.charm._certificate_is_stored = Mock(return_value=True)
         self.harness.set_can_connect(container="smf", val=True)
-        patch_exists.side_effect = [True, True, False, True]
+        patch_exists.side_effect = [True, True, True, False, True]
         patch_nrf_url.return_value = "http://nrf.com:8080"
 
         self.harness.charm._configure_sdcore_smf(event=Mock())
@@ -360,6 +433,10 @@ class TestCharm(unittest.TestCase):
         patch_nrf_url.return_value = "http://nrf.com:8080"
         self._database_is_available()
         self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
+        self.harness.charm._certificate_is_stored = Mock(return_value=True)
         self.harness.set_can_connect(container="smf", val=True)
 
         self.harness.charm._configure_sdcore_smf(event=Mock())
@@ -384,6 +461,10 @@ class TestCharm(unittest.TestCase):
         patch_pull.return_value = StringIO("super different config file content")
         self._database_is_available()
         self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
+        self.harness.charm._certificate_is_stored = Mock(return_value=True)
         self.harness.set_can_connect(container="smf", val=True)
         patch_exists.side_effect = [True, True, False, True]
         patch_nrf_url.return_value = "http://nrf.com:8080"
@@ -408,6 +489,10 @@ class TestCharm(unittest.TestCase):
         patch_check_output.return_value = pod_ip.encode()
         self._database_is_available()
         self._create_nrf_relation()
+        self.harness.add_relation(
+            relation_name="certificates", remote_app="tls-certificates-operator"
+        )
+        self.harness.charm._certificate_is_stored = Mock(return_value=True)
         self.harness.set_can_connect(container=self.container_name, val=True)
         patch_nrf_url.return_value = "http://nrf:8000"
         patch_exists.return_value = True

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -328,7 +328,7 @@ class TestCharm(unittest.TestCase):
     @patch("charm.check_output")
     @patch("ops.model.Container.push")
     @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    def test_given_certificate_is_not_stored_when_configure_sdcore_smff_then_status_is_waiting(  # noqa: E501
+    def test_given_certificate_is_not_stored_when_configure_sdcore_smf_then_status_is_waiting(  # noqa: E501
         self,
         patch_nrf_url,
         patch_push,


### PR DESCRIPTION
# Description

Enforces TLS integration in the charm. Charm remains in blocked state until the `certificates` relation is created, and in waiting status until a certificate is stored.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
