### PR TITLE
Use `integrate()` instead of `add_relation()`

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -21,7 +21,8 @@ TLS_PROVIDER_APP_NAME = "self-signed-certificates"
 
 async def _deploy_database(ops_test: OpsTest):
     """Deploy a MongoDB."""
-    await ops_test.model.deploy(  # type: ignore[union-attr]
+    assert ops_test.model
+    await ops_test.model.deploy(
         DATABASE_APP_NAME,
         application_name=DATABASE_APP_NAME,
         channel="5/edge",
@@ -31,7 +32,8 @@ async def _deploy_database(ops_test: OpsTest):
 
 async def _deploy_nrf(ops_test: OpsTest):
     """Deploy a NRF."""
-    await ops_test.model.deploy(  # type: ignore[union-attr]
+    assert ops_test.model
+    await ops_test.model.deploy(
         NRF_APP_NAME,
         application_name=NRF_APP_NAME,
         channel="edge",
@@ -41,7 +43,8 @@ async def _deploy_nrf(ops_test: OpsTest):
 
 async def _deploy_tls_provider(ops_test: OpsTest):
     """Deploy a TLS provider."""
-    await ops_test.model.deploy(  # type: ignore[union-attr]
+    assert ops_test.model
+    await ops_test.model.deploy(
         TLS_PROVIDER_APP_NAME,
         application_name=TLS_PROVIDER_APP_NAME,
         channel="beta",
@@ -52,11 +55,12 @@ async def _deploy_tls_provider(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def build_and_deploy(ops_test: OpsTest):
     """Build the charm-under-test and deploy it."""
+    assert ops_test.model
     charm = await ops_test.build_charm(".")
     resources = {
         "smf-image": METADATA["resources"]["smf-image"]["upstream-source"],
     }
-    await ops_test.model.deploy(  # type: ignore[union-attr]
+    await ops_test.model.deploy(
         charm,
         resources=resources,
         application_name=APP_NAME,
@@ -71,7 +75,8 @@ async def build_and_deploy(ops_test: OpsTest):
 async def test_given_charm_is_built_when_deployed_then_status_is_blocked(
     ops_test: OpsTest, build_and_deploy
 ):
-    await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
+    assert ops_test.model
+    await ops_test.model.wait_for_idle(
         apps=[APP_NAME],
         status="blocked",
         timeout=1000,
@@ -80,16 +85,17 @@ async def test_given_charm_is_built_when_deployed_then_status_is_blocked(
 
 @pytest.mark.abort_on_fail
 async def test_relate_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
-    await ops_test.model.add_relation(  # type: ignore[union-attr]
+    assert ops_test.model
+    await ops_test.model.integrate(
         relation1=f"{NRF_APP_NAME}:database", relation2=f"{DATABASE_APP_NAME}"
     )
-    await ops_test.model.add_relation(  # type: ignore[union-attr]
+    await ops_test.model.integrate(
         relation1=f"{APP_NAME}:database", relation2=f"{DATABASE_APP_NAME}"
     )
-    await ops_test.model.add_relation(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
-    await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
-    await ops_test.model.add_relation(relation1=APP_NAME, relation2=TLS_PROVIDER_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
-    await ops_test.model.wait_for_idle(  # type: ignore[union-attr]
+    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)
+    await ops_test.model.integrate(relation1=APP_NAME, relation2=NRF_APP_NAME)
+    await ops_test.model.integrate(relation1=APP_NAME, relation2=TLS_PROVIDER_APP_NAME)
+    await ops_test.model.wait_for_idle(
         apps=[APP_NAME],
         status="active",
         timeout=1000,
@@ -98,41 +104,45 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, build_and_de
 
 @pytest.mark.abort_on_fail
 async def test_remove_nrf_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
-    await ops_test.model.remove_application(NRF_APP_NAME, block_until_done=True)  # type: ignore[union-attr]  # noqa: E501
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)  # type: ignore[union-attr]  # noqa: E501
+    assert ops_test.model
+    await ops_test.model.remove_application(NRF_APP_NAME, block_until_done=True)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)
 
 
 @pytest.mark.abort_on_fail
 async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
-    await ops_test.model.deploy(  # type: ignore[union-attr]
+    assert ops_test.model
+    await ops_test.model.deploy(
         NRF_APP_NAME,
         application_name=NRF_APP_NAME,
         channel="edge",
         trust=True,
     )
-    await ops_test.model.add_relation(  # type: ignore[union-attr]
+    await ops_test.model.integrate(
         relation1=f"{NRF_APP_NAME}:database", relation2=DATABASE_APP_NAME
     )
-    await ops_test.model.add_relation(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
-    await ops_test.model.add_relation(relation1=APP_NAME, relation2=NRF_APP_NAME)  # type: ignore[union-attr]  # noqa: E501
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.integrate(relation1=NRF_APP_NAME, relation2=TLS_PROVIDER_APP_NAME)
+    await ops_test.model.integrate(relation1=APP_NAME, relation2=NRF_APP_NAME)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
 
 
 @pytest.mark.abort_on_fail
 async def test_remove_tls_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
-    await ops_test.model.remove_application(TLS_PROVIDER_APP_NAME, block_until_done=True)  # type: ignore[union-attr]  # noqa: E501
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)  # type: ignore[union-attr]  # noqa: E501
+    assert ops_test.model
+    await ops_test.model.remove_application(TLS_PROVIDER_APP_NAME, block_until_done=True)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)
 
 
 @pytest.mark.abort_on_fail
 async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, build_and_deploy):
-    await ops_test.model.deploy(  # type: ignore[union-attr]
+    assert ops_test.model
+    await ops_test.model.deploy(
         TLS_PROVIDER_APP_NAME,
         application_name=TLS_PROVIDER_APP_NAME,
         channel="beta",
         trust=True,
     )
-    await ops_test.model.add_relation(  # type: ignore[union-attr]
+    await ops_test.model.integrate(
         relation1=APP_NAME, relation2=TLS_PROVIDER_APP_NAME
     )
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)  # type: ignore[union-attr]  # noqa: E501
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -142,7 +142,5 @@ async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, build_a
         channel="beta",
         trust=True,
     )
-    await ops_test.model.integrate(
-        relation1=APP_NAME, relation2=TLS_PROVIDER_APP_NAME
-    )
+    await ops_test.model.integrate(relation1=APP_NAME, relation2=TLS_PROVIDER_APP_NAME)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)


### PR DESCRIPTION
`add_relation()` is deprecated and will be remove in the future. This removes the warning log.

Also, assert assumptions instead of ignoring the type checker.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
