### PR TITLE
fix: Disable kafka as it is not deployed in Charmed-5G

### DIFF
--- a/src/templates/smfcfg.yaml.j2
+++ b/src/templates/smfcfg.yaml.j2
@@ -15,6 +15,8 @@ configuration:
   debugProfilePort: 5001
   mongodb:
     url: {{ database_url }}
+  kafkaInfo:
+    enableKafka: false
   smfName: SMF
   sbi:
     scheme: {{ scheme }}

--- a/tests/unit/expected_smfcfg.yaml
+++ b/tests/unit/expected_smfcfg.yaml
@@ -15,6 +15,8 @@ configuration:
   debugProfilePort: 5001
   mongodb:
     url: http://6.5.6.5
+  kafkaInfo:
+    enableKafka: false
   smfName: SMF
   sbi:
     scheme: https


### PR DESCRIPTION
# Description

Disables Kafka as it is not deployed in Charmed-5G

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
