### PR TITLE
chore: Rename SD-Core charms by adding -k8s as a suffix

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
   integration-test:
     uses: canonical/sdcore-github-workflows/.github/workflows/integration-test.yaml@main
     with:
-      charm-file-name: "sdcore-smf_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-smf-k8s_ubuntu-22.04-amd64.charm"
 
   publish-charm:
     name: Publish Charm
@@ -39,5 +39,5 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
     with:
-      charm-file-name: "sdcore-smf_ubuntu-22.04-amd64.charm"
+      charm-file-name: "sdcore-smf-k8s_ubuntu-22.04-amd64.charm"
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# SD-Core SMF K8s Operator
+# SD-Core SMF Operator for K8s
 [![CharmHub Badge](https://charmhub.io/sdcore-smf-k8s/badge.svg)](https://charmhub.io/sdcore-smf-k8s)
 
-Charmed K8s Operator for the SD-Core Session Management Function (SMF).
+Charmed Operator for the SD-Core Session Management Function (SMF) for K8s.
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# SD-Core SMF Operator (k8s)
-[![CharmHub Badge](https://charmhub.io/sdcore-smf/badge.svg)](https://charmhub.io/sdcore-smf)
+# SD-Core SMF K8s Operator
+[![CharmHub Badge](https://charmhub.io/sdcore-smf-k8s/badge.svg)](https://charmhub.io/sdcore-smf-k8s)
 
-Charmed Operator for the SD-Core Session Management Function (SMF).
+Charmed K8s Operator for the SD-Core Session Management Function (SMF).
 
 # Usage
 
 ```bash
 juju deploy mongodb-k8s --channel 5/edge --trust
-juju deploy sdcore-smf --channel edge
-juju deploy sdcore-nrf --channel edge
+juju deploy sdcore-smf-k8s --channel edge
+juju deploy sdcore-nrf-k8s --channel edge
 juju deploy self-signed-certificates --channel=beta
-juju integrate sdcore-smf:default-database mongodb-k8s
-juju integrate sdcore-smf:smf-database mongodb-k8s
-juju integrate sdcore-nrf:certificates self-signed-certificates:certificates
-juju integrate sdcore-smf:fiveg_nrf sdcore-nrf
-juju integrate sdcore-smf:certificates self-signed-certificates:certificates
+juju integrate sdcore-smf-k8s:default-database mongodb-k8s
+juju integrate sdcore-smf-k8s:smf-database mongodb-k8s
+juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
+juju integrate sdcore-smf-k8s:fiveg_nrf sdcore-nrf-k8s:fiveg_nrf
+juju integrate sdcore-smf-k8s:certificates self-signed-certificates:certificates
 ```
 
 # Image

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SD-Core SMF Operator for K8s
+# SD-Core SMF Operator (k8s)
 [![CharmHub Badge](https://charmhub.io/sdcore-smf-k8s/badge.svg)](https://charmhub.io/sdcore-smf-k8s)
 
 Charmed Operator for the SD-Core Session Management Function (SMF) for K8s.

--- a/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
+++ b/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
@@ -13,7 +13,7 @@ NRF information and another charm requiring this information.
 From a charm directory, fetch the library using `charmcraft`:
 
 ```shell
-charmcraft fetch-lib charms.sdcore_nrf.v0.fiveg_nrf
+charmcraft fetch-lib charms.sdcore_nrf_k8s_k8s.v0.fiveg_nrf
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
@@ -28,7 +28,7 @@ Example:
 from ops.charm import CharmBase
 from ops.main import main
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFAvailableEvent, NRFRequires
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFAvailableEvent, NRFRequires
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +58,7 @@ Example:
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFProvides
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFProvides
 
 
 class DummyFiveGNRFProviderCharm(CharmBase):
@@ -103,14 +103,14 @@ from ops.model import Relation
 from pydantic import AnyHttpUrl, BaseModel, Field, ValidationError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "cd132a12c2b34243bfd2bae8d08c32d6"
+LIBID = "14746bb6f8d34accbeac27ea50ff4715"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 1
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
-name: sdcore-smf
-display-name: SD-Core 5G SMF
+name: sdcore-smf-k8s
+display-name: SD-Core 5G SMF K8s
 summary: Charmed Operator for the SD-Core Session Management Function (SMF).
 description: Charmed Operator for the SD-Core Session Management Function (SMF).
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -14,7 +14,7 @@ from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires  # typ
 from charms.prometheus_k8s.v0.prometheus_scrape import (  # type: ignore[import]  # noqa: E501
     MetricsEndpointProvider,
 )
-from charms.sdcore_nrf.v0.fiveg_nrf import NRFRequires  # type: ignore[import]
+from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFRequires  # type: ignore[import]
 from charms.tls_certificates_interface.v2.tls_certificates import (  # type: ignore[import]
     CertificateAvailableEvent,
     CertificateExpiringEvent,

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed K8s operator for the 5G SMF service."""
+"""Charmed operator for the 5G SMF service for K8s."""
 
 
 import logging
@@ -44,7 +44,7 @@ CERTIFICATE_NAME = "smf.pem"
 CERTIFICATE_COMMON_NAME = "smf.sdcore"
 
 
-class SMFK8sOperatorCharm(CharmBase):
+class SMFOperatorCharm(CharmBase):
     """Charm the service."""
 
     def __init__(self, *args):
@@ -558,4 +558,4 @@ def _get_pod_ip() -> Optional[str]:
 
 
 if __name__ == "__main__":  # pragma: nocover
-    main(SMFK8sOperatorCharm)
+    main(SMFOperatorCharm)

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charmed operator for the 5G SMF service."""
+"""Charmed K8s operator for the 5G SMF service."""
 
 
 import logging
@@ -44,7 +44,7 @@ CERTIFICATE_NAME = "smf.pem"
 CERTIFICATE_COMMON_NAME = "smf.sdcore"
 
 
-class SMFOperatorCharm(CharmBase):
+class SMFK8sOperatorCharm(CharmBase):
     """Charm the service."""
 
     def __init__(self, *args):
@@ -558,4 +558,4 @@ def _get_pod_ip() -> Optional[str]:
 
 
 if __name__ == "__main__":  # pragma: nocover
-    main(SMFOperatorCharm)
+    main(SMFK8sOperatorCharm)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,7 @@ flake8-docstrings
 flake8-builtins
 isort
 juju>=3.1
+macaroonbakery==1.3.2  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
 pep8-naming
 pyproject-flake8

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
-NRF_APP_NAME = "sdcore-nrf"
+NRF_APP_NAME = "sdcore-nrf-k8s"
 DATABASE_APP_NAME = "mongodb-k8s"
 TLS_PROVIDER_APP_NAME = "self-signed-certificates"
 

--- a/tests/unit/expected_smfcfg.yaml
+++ b/tests/unit/expected_smfcfg.yaml
@@ -20,7 +20,7 @@ configuration:
   smfName: SMF
   sbi:
     scheme: https
-    registerIPv4: sdcore-smf.whatever.svc.cluster.local
+    registerIPv4: sdcore-smf-k8s.whatever.svc.cluster.local
     bindingIPv4: 0.0.0.0
     port: 29502
     tls:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,7 +9,7 @@ import yaml
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
-from charm import SMFK8sOperatorCharm
+from charm import SMFOperatorCharm
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ class TestCharm(unittest.TestCase):
         self.database_application_name = "mongodb-k8s"
         self.metadata = self._get_metadata()
         self.container_name = list(self.metadata["containers"].keys())[0]
-        self.harness = testing.Harness(SMFK8sOperatorCharm)
+        self.harness = testing.Harness(SMFOperatorCharm)
         self.harness.set_model_name(name=self.namespace)
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(is_leader=True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,7 +9,7 @@ import yaml
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 
-from charm import SMFOperatorCharm
+from charm import SMFK8sOperatorCharm
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ class TestCharm(unittest.TestCase):
         self.database_application_name = "mongodb-k8s"
         self.metadata = self._get_metadata()
         self.container_name = list(self.metadata["containers"].keys())[0]
-        self.harness = testing.Harness(SMFOperatorCharm)
+        self.harness = testing.Harness(SMFK8sOperatorCharm)
         self.harness.set_model_name(name=self.namespace)
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(is_leader=True)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -168,7 +168,7 @@ class TestCharm(unittest.TestCase):
             BlockedStatus("Waiting for `certificates` relation to be created"),
         )
 
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url")
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url")
     @patch("charm.check_output")
     def test_given_smf_charm_in_active_status_when_nrf_relation_breaks_then_status_is_blocked(
         self, patch_check_output, patch_nrf_url
@@ -196,7 +196,7 @@ class TestCharm(unittest.TestCase):
             BlockedStatus("Waiting for fiveg_nrf relation"),
         )
 
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url")
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url")
     @patch("charm.check_output")
     def test_given_smf_charm_in_active_status_when_database_relation_breaks_then_status_is_blocked(
         self, patch_check_output, patch_nrf_url
@@ -275,7 +275,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url")
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url")
     def test_given_ue_config_file_is_not_written_when_configure_sdcore_smf_is_called_then_status_is_waiting(  # noqa: E501
         self,
         patch_nrf_url,
@@ -300,7 +300,7 @@ class TestCharm(unittest.TestCase):
             ),
         )
 
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url")
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url")
     def test_given_storage_is_not_attached_when_configure_sdcore_smf_is_called_then_status_is_waiting(  # noqa: E501
         self, patch_nrf_url
     ):
@@ -317,7 +317,7 @@ class TestCharm(unittest.TestCase):
             WaitingStatus("Waiting for storage to be attached"),
         )
 
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url")
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url")
     @patch("charm.check_output")
     def test_given_ip_not_available_when_configure_then_status_is_waiting(
         self,
@@ -342,7 +342,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_certificate_is_not_stored_when_configure_sdcore_smf_then_status_is_waiting(  # noqa: E501
         self,
         patch_nrf_url,
@@ -368,7 +368,7 @@ class TestCharm(unittest.TestCase):
             self.harness.model.unit.status, WaitingStatus("Waiting for certificates to be stored")
         )
 
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url")
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url")
     @patch("charm.check_output")
     def test_given_config_files_and_relations_are_created_when_configure_sdcore_smf_is_called_then_status_is_active(  # noqa: E501
         self,
@@ -397,7 +397,7 @@ class TestCharm(unittest.TestCase):
             ActiveStatus(),
         )
 
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charm.check_output")
     def test_given_nrf_is_available_when_database_is_created_then_config_file_is_written_with_expected_content(  # noqa: E501
         self,
@@ -427,7 +427,7 @@ class TestCharm(unittest.TestCase):
             self._read_file("tests/unit/expected_smfcfg.yaml"),
         )
 
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charm.check_output")
     def test_given_config_file_exists_and_is_not_changed_when_configure_smf_then_config_file_is_not_re_written_with_same_content(  # noqa: E501
         self,
@@ -458,7 +458,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual((root / "etc/smf/smfcfg.yaml").stat().st_mtime, config_modification_time)
 
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     @patch("charm.check_output")
     def test_given_config_file_exists_and_is_changed_when_configure_smf_then_config_file_is_updated(  # noqa: E501
         self,
@@ -489,7 +489,7 @@ class TestCharm(unittest.TestCase):
             self._read_file("tests/unit/expected_smfcfg.yaml"),
         )
 
-    @patch("charms.sdcore_nrf.v0.fiveg_nrf.NRFRequires.nrf_url")
+    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url")
     @patch("charm.check_output")
     def test_given_config_files_and_relations_are_created_when_configure_sdcore_smf_is_called_then_expected_plan_is_applied(  # noqa: E501
         self, patch_check_output, patch_nrf_url


### PR DESCRIPTION
# Description

Add -k8s as a suffix in both github and Charmhub name to follow [TE042](https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit) . 

- Fetch new fiveg_nrf library
- Pin macaroonbakery to 1.3.2 which installed by juju client indirectly through pytest_operator.
      - The next protobuf version 4.21.0 has the breaking changes with the existing code
      - https://protobuf.dev/news/2022-05-06/#python-updates

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
